### PR TITLE
remove create ppa list

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ To build this ppa I follow this [assafmo guide](https://assafmo.github.io/2019/0
 ```
 gpg --import ../piero.proietti-my-private-key.asc 
 gpg --armor --export piero.proietti@gmail.com > KEY.gpg
-echo "deb https://pieroproietti.github.io/penguins-eggs-ppa ./" > penguins-eggs-ppa.list
 ```
 
 ### Update debs


### PR DESCRIPTION
fix little thing..

i think, this repo already support multi-architect. wherever you put file deb it's not problem because system will select automatically with distro architect use.

i recommend to rearrange file by version, example:
```
- v1
-- eggs_v1.amd64.deb
-- eggs_v1.i368deb
-- eggs_xxx.deb
```

it will fix paging issue when eggs have already many version